### PR TITLE
Declare emoji list as local variable

### DIFF
--- a/company-emoji.el
+++ b/company-emoji.el
@@ -1290,27 +1290,27 @@ is a single candidate, as when COMMAND is 'annotation' or
 
   ;; First, update the list of candidates by adding the custom
   ;; aliases:
-  (setq company-emoji-list (company-emoji--add-aliases
-                             company-emoji-aliases
-                             (company-emoji--create-list)))
-  (cl-case command
-    ;; 'prefix' has too many meanings in emacs lisp but here we're
-    ;; specifying what the string we're completing should begin with
-    (prefix (company-grab "\:[a-zA-Z0-9-_]*"))
-    (candidates
-      ;; filter based on what's already been typed
-      (cl-remove-if-not
+  (let ((emoji-list (company-emoji--add-aliases
+                     company-emoji-aliases
+                     (company-emoji--create-list))))
+    (cl-case command
+      ;; 'prefix' has too many meanings in emacs lisp but here we're
+      ;; specifying what the string we're completing should begin with
+      (prefix (company-grab "\:[a-zA-Z0-9-_]*"))
+      (candidates
+       ;; filter based on what's already been typed
+       (cl-remove-if-not
         (lambda (c) (string-prefix-p arg c))
-        company-emoji-list))
-    ;; show the real emoji alongside its name in the completion list
-    (annotation (company-emoji--annotation arg))
-    ;; when we find the emoji we want, replace it with the real emoji
-    ;; (assuming company-emoji-insert-unicode is set to true)
-    (post-completion
-      (if company-emoji-insert-unicode
-        (progn
-          (kill-region (- (point) (length arg)) (point))
-          (insert (get-text-property 0 :unicode arg)))))))
+        emoji-list))
+      ;; show the real emoji alongside its name in the completion list
+      (annotation (company-emoji--annotation arg))
+      ;; when we find the emoji we want, replace it with the real emoji
+      ;; (assuming company-emoji-insert-unicode is set to true)
+      (post-completion
+       (if company-emoji-insert-unicode
+           (progn
+             (kill-region (- (point) (length arg)) (point))
+             (insert (get-text-property 0 :unicode arg))))))))
 
 ;;;###autoload
 (defun company-emoji-init ()


### PR DESCRIPTION
It is not necessary as global variable and it causes byte-compile warning.

```
In company-emoji:                                                                 
company-emoji.el:1304:9:Warning: assignment to free variable                      
    `company-emoji-list'                                                          
company-emoji.el:1303:42:Warning: reference to free variable                      
    `company-emoji-list' 
```
