### PR TITLE
Sort company-emojis list

### DIFF
--- a/company-emoji.el
+++ b/company-emoji.el
@@ -116,11 +116,13 @@
 (require 'cl-lib)
 (require 'company)
 (require 'company-emoji-list)
+(require 'dash)
 
 (defconst company-emoji-version "2.5.1"
   "Current version of company-emoji.")
 
-(defconst company-emojis (company-emoji-list-create)
+(defconst company-emojis (-sort 'string-lessp
+																(company-emoji-list-create))
   "Cached list of propertized emojis.")
 
 ;; customize


### PR DESCRIPTION
* company-emoji.el: Require (`dash.el`).  Sort list (`company-emojis`).

problem:
After first completion with `company-emoji`, the `company-emoji` list was cut and started only from the first element `:grinning:` of the list `company-emoji-list-create`.