### PR TITLE
The thumbs up sign(:+1:) isn't listed on company-emoji candidate

### DIFF
--- a/company-emoji.el
+++ b/company-emoji.el
@@ -198,7 +198,7 @@ is a single candidate, as when COMMAND is 'annotation' or
     (cl-case command
       ;; 'prefix' has too many meanings in emacs lisp but here we're
       ;; specifying what the string we're completing should begin with
-      (prefix (company-grab "\:[a-zA-Z0-9-_]*"))
+      (prefix (company-grab "\:[a-zA-Z0-9-_+]*"))
       (candidates
        ;; filter based on what's already been typed
        (cl-remove-if-not


### PR DESCRIPTION
The thumbs up sing isn't shown on company-emoji candidate list because
company-grab doesn't include '+'.
Therefore I add '+' to company-grab.